### PR TITLE
[torchcontrol] Add linking for torchrot

### DIFF
--- a/polymetis/CMakeLists.txt
+++ b/polymetis/CMakeLists.txt
@@ -129,11 +129,14 @@ target_link_libraries(polymetis_server
     ${TORCH_LIBRARIES}
     yaml-cpp
     torchscript_pinocchio
+    torchrot
 )
 target_link_libraries(polymetis_server -Wl,--no-as-needed torchscript_pinocchio)
+target_link_libraries(polymetis_server -Wl,--no-as-needed torchrot)
 
 add_executable(run_server "src/run_server.cpp")
 target_link_libraries(run_server polymetis_server -Wl,--no-as-needed torchscript_pinocchio)
+target_link_libraries(run_server polymetis_server -Wl,--no-as-needed torchrot)
 
 # Add test client
 add_executable(empty_statistics_client "src/clients/empty_statistics_client.cpp"

--- a/polymetis/python/torchcontrol/modules/feedback.py
+++ b/polymetis/python/torchcontrol/modules/feedback.py
@@ -137,7 +137,7 @@ class CartesianSpacePD(toco.ControlModule):
         # Feedback law
         output = self.Kp @ ee_pose_err + self.Kd @ ee_twist_err
 
-        # Return torques projected back to joint space
+        # Return forces
         return output
 
 
@@ -166,7 +166,8 @@ class OperationalSpacePD(toco.ControlModule):
 
         Kp = diagonalize_gain(to_tensor(Kp))
         Kd = diagonalize_gain(to_tensor(Kd))
-        assert Kp.shape == Kd.shape
+        assert Kp.shape == torch.Size([6, 6])
+        assert Kd.shape == torch.Size([6, 6])
 
         self.Kp = torch.nn.Parameter(Kp)
         self.Kd = torch.nn.Parameter(Kd)

--- a/tests/scripts/2_toco_policies.py
+++ b/tests/scripts/2_toco_policies.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import time
+
+import torch
+
+from polymetis import RobotInterface
+import torchcontrol as toco
+
+num_dofs = 7
+time_to_go = 0.1
+
+
+def run_unending_policy(robot, policy, time_to_go):
+    robot.send_torch_policy(policy, blocking=False)
+    time.sleep(time_to_go)
+    robot.terminate_current_policy()
+
+
+if __name__ == "__main__":
+    # Initialize robot interface
+    robot = RobotInterface(
+        ip_address="localhost",
+    )
+    robot.go_home()
+    time.sleep(0.5)
+
+    # Params
+    hz = robot.metadata.hz
+    robot_model = robot.robot_model
+    joint_pos_current = robot.get_joint_angles()
+    time_horizon = int(time_to_go * hz)
+
+    # Run torchcontrol policies
+    print("=== torchcontrol.policies.JointImpedanceControl ===")
+    policy = toco.policies.JointImpedanceControl(
+        joint_pos_current=joint_pos_current,
+        Kp=torch.zeros(num_dofs, num_dofs),
+        Kd=torch.zeros(num_dofs, num_dofs),
+        robot_model=robot_model,
+    )
+    run_unending_policy(robot, policy, time_to_go)
+
+    print("=== torchcontrol.policies.CartesianImpedanceControl ===")
+    policy = toco.policies.CartesianImpedanceControl(
+        joint_pos_current=joint_pos_current,
+        Kp=torch.zeros(num_dofs),
+        Kd=torch.zeros(num_dofs),
+        robot_model=robot_model,
+    )
+    run_unending_policy(robot, policy, time_to_go)
+
+    print("=== torchcontrol.policies.iLQR ===")
+    policy = toco.policies.iLQR(
+        Kxs=torch.zeros(time_horizon, num_dofs, 2 * num_dofs),
+        x_desireds=torch.zeros(time_horizon, 2 * num_dofs),
+        u_ffs=torch.zeros(time_horizon, num_dofs),
+    )
+    robot.send_torch_policy(policy)

--- a/tests/scripts/2_toco_policies.py
+++ b/tests/scripts/2_toco_policies.py
@@ -46,8 +46,8 @@ if __name__ == "__main__":
     print("=== torchcontrol.policies.CartesianImpedanceControl ===")
     policy = toco.policies.CartesianImpedanceControl(
         joint_pos_current=joint_pos_current,
-        Kp=torch.zeros(num_dofs),
-        Kd=torch.zeros(num_dofs),
+        Kp=torch.zeros(6, 6),
+        Kd=torch.zeros(6, 6),
         robot_model=robot_model,
     )
     run_unending_policy(robot, policy, time_to_go)


### PR DESCRIPTION
Fixes issue where `torchcontrol.transform` objects aren't runnable when loaded in PolymetisServer.

## Changes proposed:
Link torchrot to polymetis_server & run_server

## Test plan:
<!--
How did you verify your changes are correct?
Did you add unit tests?
-->
Add integration test that ensures all torchcontrol policies are runnable, some of which involves using torchcontrol.transform.
