### PR TITLE
Revamp controller input dictionary

### DIFF
--- a/examples/2_custom_controller.py
+++ b/examples/2_custom_controller.py
@@ -40,8 +40,8 @@ class MySinePolicy(toco.PolicyModule):
 
     def forward(self, state_dict: Dict[str, torch.Tensor]):
         # Parse states
-        q_current = state_dict["joint_pos"]
-        qd_current = state_dict["joint_vel"]
+        q_current = state_dict["joint_positions"]
+        qd_current = state_dict["joint_velocities"]
 
         # Initialize
         if self.steps == 0:
@@ -64,7 +64,7 @@ class MySinePolicy(toco.PolicyModule):
             self.set_terminated()
         self.steps += 1
 
-        return {"torque_desired": output}
+        return {"joint_torques": output}
 
 
 if __name__ == "__main__":

--- a/examples/3_custom_updatable_controller.py
+++ b/examples/3_custom_updatable_controller.py
@@ -32,15 +32,15 @@ class MyPDPolicy(toco.PolicyModule):
 
     def forward(self, state_dict: Dict[str, torch.Tensor]):
         # Parse states
-        q_current = state_dict["joint_pos"]
-        qd_current = state_dict["joint_vel"]
+        q_current = state_dict["joint_positions"]
+        qd_current = state_dict["joint_velocities"]
 
         # Execute PD control
         output = self.feedback(
             q_current, qd_current, self.q_desired, torch.zeros_like(qd_current)
         )
 
-        return {"torque_desired": output}
+        return {"joint_torques": output}
 
 
 if __name__ == "__main__":

--- a/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/include/polymetis/polymetis_server.hpp
@@ -163,14 +163,6 @@ private:
   int num_dofs_;
   long int threshold_ns_ = THRESHOLD_NS;
 
-  torch::Tensor timestamp_;
-  torch::Tensor joint_pos_;
-  torch::Tensor joint_vel_;
-  c10::Dict<std::string, torch::Tensor> state_dict_;
-  std::vector<torch::jit::IValue> input_;
-  std::vector<torch::jit::IValue> empty_input_;
-  std::vector<torch::jit::IValue> param_dict_input_;
-
   std::mutex service_mtx_;
 
   CircularBuffer<RobotState> robot_state_buffer_ =
@@ -178,6 +170,18 @@ private:
 
   CustomControllerContext custom_controller_context_;
   RobotClientContext robot_client_context_;
+
+  // Robot states
+  torch::Tensor rs_timestamp_;
+  torch::Tensor rs_joint_positions_;
+  torch::Tensor rs_joint_velocities_;
+
+  c10::Dict<std::string, torch::Tensor> state_dict_;
+
+  // Inputs
+  std::vector<torch::jit::IValue> input_;
+  std::vector<torch::jit::IValue> empty_input_;
+  std::vector<torch::jit::IValue> param_dict_input_;
 };
 
 #endif

--- a/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/include/polymetis/polymetis_server.hpp
@@ -175,6 +175,8 @@ private:
   torch::Tensor rs_timestamp_;
   torch::Tensor rs_joint_positions_;
   torch::Tensor rs_joint_velocities_;
+  torch::Tensor rs_motor_torques_measured_;
+  torch::Tensor rs_motor_torques_external_;
 
   c10::Dict<std::string, torch::Tensor> state_dict_;
 

--- a/polymetis/python/polysim/envs/bullet_locomotor.py
+++ b/polymetis/python/polysim/envs/bullet_locomotor.py
@@ -87,11 +87,11 @@ class DaisyLocomotorEnv(AbstractControlledEnv):
         # concatenating the joint pos and base state for controllers like ilqr
         # joint_pos should probably be renamed as generalized coordinates or something
         base_pos = self.get_current_base_pos()
-        self.robot_state["joint_pos"] = np.hstack(
+        self.robot_state["joint_positions"] = np.hstack(
             [state["j_pos"], base_pos, state["base_ori_euler"]]
         ).tolist()
         base_vel = self.get_current_base_vel()
-        self.robot_state["joint_vel"] = np.hstack(
+        self.robot_state["joint_velocities"] = np.hstack(
             [state["j_vel"], base_vel, state["base_ang_vel"]]
         ).tolist()
         self.robot_state["joint_acc"] = state["j_eff"]  # TODO: fill in this field

--- a/polymetis/python/torchcontrol/policies/default_controller.py
+++ b/polymetis/python/torchcontrol/policies/default_controller.py
@@ -29,8 +29,8 @@ class DefaultController(toco.PolicyModule):
         self.running = False
 
     def forward(self, state_dict: Dict[str, torch.Tensor]):
-        joint_pos_current = state_dict["joint_pos"]
-        joint_vel_current = state_dict["joint_vel"]
+        joint_pos_current = state_dict["joint_positions"]
+        joint_vel_current = state_dict["joint_velocities"]
 
         # Set reference joint position
         if not self.running:
@@ -45,4 +45,4 @@ class DefaultController(toco.PolicyModule):
             torch.zeros_like(self.joint_pos_desired),
         )
 
-        return {"torque_desired": torque_feedback}
+        return {"joint_torques": torque_feedback}

--- a/polymetis/python/torchcontrol/policies/ee_pd.py
+++ b/polymetis/python/torchcontrol/policies/ee_pd.py
@@ -63,8 +63,8 @@ class CartesianImpedanceControl(toco.PolicyModule):
             A dictionary containing the controller output
         """
         # State extraction
-        joint_pos_current = state_dict["joint_pos"]
-        joint_vel_current = state_dict["joint_vel"]
+        joint_pos_current = state_dict["joint_positions"]
+        joint_vel_current = state_dict["joint_velocities"]
 
         # Desired state
         ee_pose_desired = T.from_rot_xyz(
@@ -82,4 +82,4 @@ class CartesianImpedanceControl(toco.PolicyModule):
         )  # coriolis
         torque_out = torque_feedback + torque_feedforward
 
-        return {"torque_desired": torque_out}
+        return {"joint_torques": torque_out}

--- a/polymetis/python/torchcontrol/policies/ilqr.py
+++ b/polymetis/python/torchcontrol/policies/ilqr.py
@@ -56,7 +56,9 @@ class iLQR(toco.PolicyModule):
             A dictionary containing the controller output
         """
         # Extract state vector
-        x = torch.cat([state_dict["joint_pos"], state_dict["joint_vel"]], dim=-1)
+        x = torch.cat(
+            [state_dict["joint_positions"], state_dict["joint_velocities"]], dim=-1
+        )
 
         # Select linear feedback gains & reference
         self.feedback.update({"K": self.Kxs[self.i, :, :]})
@@ -71,4 +73,4 @@ class iLQR(toco.PolicyModule):
 
         u_output = self.feedback(x, x_desired) + u_ff
 
-        return {"torque_desired": u_output}
+        return {"joint_torques": u_output}

--- a/polymetis/python/torchcontrol/policies/joint_pd.py
+++ b/polymetis/python/torchcontrol/policies/joint_pd.py
@@ -55,8 +55,8 @@ class JointImpedanceControl(toco.PolicyModule):
             A dictionary containing the controller output
         """
         # State extraction
-        joint_pos_current = state_dict["joint_pos"]
-        joint_vel_current = state_dict["joint_vel"]
+        joint_pos_current = state_dict["joint_positions"]
+        joint_vel_current = state_dict["joint_velocities"]
 
         # Control logic
         torque_feedback = self.impedance(
@@ -70,4 +70,4 @@ class JointImpedanceControl(toco.PolicyModule):
         )  # coriolis
         torque_out = torque_feedback + torque_feedforward
 
-        return {"torque_desired": torque_out}
+        return {"joint_torques": torque_out}

--- a/polymetis/python/torchcontrol/policies/move_to.py
+++ b/polymetis/python/torchcontrol/policies/move_to.py
@@ -59,8 +59,8 @@ class JointPlanExecutor(toco.PolicyModule):
             A dictionary containing the controller output
         """
         # State extraction
-        joint_pos_current = state_dict["joint_pos"]
-        joint_vel_current = state_dict["joint_vel"]
+        joint_pos_current = state_dict["joint_positions"]
+        joint_vel_current = state_dict["joint_velocities"]
 
         # Select desired state
         q_desired, qd_desired, _ = self.plan(self.i)
@@ -79,7 +79,7 @@ class JointPlanExecutor(toco.PolicyModule):
         if self.i == self.N:
             self.set_terminated()
 
-        return {"torque_desired": torque_out}
+        return {"joint_torques": torque_out}
 
 
 class JointSpaceMoveTo(toco.PolicyModule):

--- a/polymetis/src/clients/empty_statistics_client.cpp
+++ b/polymetis/src/clients/empty_statistics_client.cpp
@@ -121,9 +121,12 @@ private:
   std::unique_ptr<PolymetisControllerServer::Stub> stub_;
   bool SendCommand(int num_dofs) {
     RobotState state_;
+    setTimestampToNow(state_.mutable_timestamp());
     for (int i = 0; i < num_dofs; i++) {
       state_.add_joint_positions(0.0);
       state_.add_joint_velocities(0.0);
+      state_.add_motor_torques_measured(0.0);
+      state_.add_motor_torques_external(0.0);
     }
 
     setTimestampToNow(state_.mutable_timestamp());

--- a/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -80,7 +80,7 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
   joint_pos_llimits_ =
       config["limits"]["joint_pos_lower"].as<std::array<double, NUM_DOFS>>();
   joint_vel_limits_ =
-      config["limits"]["joint_vel"].as<std::array<double, NUM_DOFS>>();
+      config["limits"]["joint_velocities"].as<std::array<double, NUM_DOFS>>();
   elbow_vel_limit_ = config["limits"]["elbow_vel"].as<double>();
   joint_torques_limits_ =
       config["limits"]["joint_torques"].as<std::array<double, NUM_DOFS>>();
@@ -91,16 +91,16 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
   margin_cartesian_pos_ =
       config["safety_controller"]["margins"]["cartesian_pos"].as<double>();
   margin_joint_pos_ =
-      config["safety_controller"]["margins"]["joint_pos"].as<double>();
+      config["safety_controller"]["margins"]["joint_positions"].as<double>();
   margin_joint_vel_ =
-      config["safety_controller"]["margins"]["joint_vel"].as<double>();
+      config["safety_controller"]["margins"]["joint_velocities"].as<double>();
 
   k_cartesian_pos_ =
       config["safety_controller"]["stiffness"]["cartesian_pos"].as<double>();
   k_joint_pos_ =
-      config["safety_controller"]["stiffness"]["joint_pos"].as<double>();
+      config["safety_controller"]["stiffness"]["joint_positions"].as<double>();
   k_joint_vel_ =
-      config["safety_controller"]["stiffness"]["joint_vel"].as<double>();
+      config["safety_controller"]["stiffness"]["joint_velocities"].as<double>();
 }
 
 void FrankaTorqueControlClient::run() {

--- a/polymetis/src/polymetis_server.cpp
+++ b/polymetis/src/polymetis_server.cpp
@@ -77,13 +77,13 @@ Status PolymetisControllerServerImpl::InitRobotClient(
   num_dofs_ = robot_client_metadata->dof();
 
   // Create initial state dictionary
-  timestamp_ = torch::tensor(0.0);
-  joint_pos_ = torch::zeros(num_dofs_);
-  joint_vel_ = torch::zeros(num_dofs_);
+  rs_timestamp_ = torch::tensor(0.0);
+  rs_joint_positions_ = torch::zeros(num_dofs_);
+  rs_joint_velocities_ = torch::zeros(num_dofs_);
 
-  state_dict_.insert("timestamp", timestamp_);
-  state_dict_.insert("joint_positions", joint_pos_);
-  state_dict_.insert("joint_velocities", joint_vel_);
+  state_dict_.insert("timestamp", rs_timestamp_);
+  state_dict_.insert("joint_positions", rs_joint_positions_);
+  state_dict_.insert("joint_velocities", rs_joint_velocities_);
 
   // Load default controller bytes into model buffer
   controller_model_buffer_.clear();
@@ -149,12 +149,13 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   }
 
   // Parse robot state
-  auto timestamp_msg = robot_state->timestamp();
-  auto a = timestamp_.data_ptr<float>();
-  *a = float(timestamp_msg.seconds()) + float(timestamp_msg.nanos()) * 1e-9;
+  auto rs_timestamp_msg = robot_state->timestamp();
+  auto a = rs_timestamp_.data_ptr<float>();
+  *a = float(rs_timestamp_msg.seconds()) +
+       float(rs_timestamp_msg.nanos()) * 1e-9;
   for (int i = 0; i < num_dofs_; i++) {
-    joint_pos_[i] = robot_state->joint_positions(i);
-    joint_vel_[i] = robot_state->joint_velocities(i);
+    rs_joint_positions_[i] = robot_state->joint_positions(i);
+    rs_joint_velocities_[i] = robot_state->joint_velocities(i);
   }
 
   // Select controller

--- a/polymetis/src/polymetis_server.cpp
+++ b/polymetis/src/polymetis_server.cpp
@@ -80,10 +80,14 @@ Status PolymetisControllerServerImpl::InitRobotClient(
   rs_timestamp_ = torch::tensor(0.0);
   rs_joint_positions_ = torch::zeros(num_dofs_);
   rs_joint_velocities_ = torch::zeros(num_dofs_);
+  rs_motor_torques_measured_ = torch::zeros(num_dofs_);
+  rs_motor_torques_external_ = torch::zeros(num_dofs_);
 
   state_dict_.insert("timestamp", rs_timestamp_);
   state_dict_.insert("joint_positions", rs_joint_positions_);
   state_dict_.insert("joint_velocities", rs_joint_velocities_);
+  state_dict_.insert("motor_torques_measured", rs_motor_torques_measured_);
+  state_dict_.insert("motor_torques_external", rs_motor_torques_external_);
 
   // Load default controller bytes into model buffer
   controller_model_buffer_.clear();
@@ -156,6 +160,8 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   for (int i = 0; i < num_dofs_; i++) {
     rs_joint_positions_[i] = robot_state->joint_positions(i);
     rs_joint_velocities_[i] = robot_state->joint_velocities(i);
+    rs_motor_torques_measured_[i] = robot_state->motor_torques_measured(i);
+    rs_motor_torques_external_[i] = robot_state->motor_torques_external(i);
   }
 
   // Select controller

--- a/polymetis/src/polymetis_server.cpp
+++ b/polymetis/src/polymetis_server.cpp
@@ -82,8 +82,8 @@ Status PolymetisControllerServerImpl::InitRobotClient(
   joint_vel_ = torch::zeros(num_dofs_);
 
   state_dict_.insert("timestamp", timestamp_);
-  state_dict_.insert("joint_pos", joint_pos_);
-  state_dict_.insert("joint_vel", joint_vel_);
+  state_dict_.insert("joint_positions", joint_pos_);
+  state_dict_.insert("joint_velocities", joint_vel_);
 
   // Load default controller bytes into model buffer
   controller_model_buffer_.clear();
@@ -171,7 +171,7 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
       controller->forward(input_).toGenericDict();
   custom_controller_context_.controller_mtx.unlock();
 
-  torch::jit::IValue key = torch::jit::IValue("torque_desired");
+  torch::jit::IValue key = torch::jit::IValue("joint_torques");
   torch::Tensor desired_torque = controller_state_dict.at(key).toTensor();
 
   for (int i = 0; i < num_dofs_; i++) {

--- a/polymetis/tests/cpp/test_server.cpp
+++ b/polymetis/tests/cpp/test_server.cpp
@@ -201,6 +201,8 @@ int main(int argc, char **argv) {
   for (int i = 0; i < metadata_.dof(); i++) {
     dummy_robot_state_.add_joint_positions(0);
     dummy_robot_state_.add_joint_velocities(0);
+    dummy_robot_state_.add_motor_torques_measured(0);
+    dummy_robot_state_.add_motor_torques_external(0);
   }
 
   return RUN_ALL_TESTS();

--- a/polymetis/tests/python/polymetis/test_policies.py
+++ b/polymetis/tests/python/polymetis/test_policies.py
@@ -107,7 +107,7 @@ def test_policy(policy_class, policy_kwargs, is_terminating, update_params):
 
     for t in range(time_horizon):
         assert not scripted_policy.is_terminated()
-        inputs = {"joint_pos": torch.zeros(7), "joint_vel": torch.zeros(7)}
+        inputs = {"joint_positions": torch.zeros(7), "joint_velocities": torch.zeros(7)}
         scripted_policy.forward(inputs)
 
     if is_terminating:

--- a/polymetis/tests/python/polymetis/test_policy_performance.py
+++ b/polymetis/tests/python/polymetis/test_policy_performance.py
@@ -20,7 +20,7 @@ def policy(request):
 
 @pytest.mark.benchmark(group="non-scripted")
 def test_policy_performance(policy, benchmark):
-    inputs = {"joint_pos": torch.zeros(7), "joint_vel": torch.zeros(7)}
+    inputs = {"joint_positions": torch.zeros(7), "joint_velocities": torch.zeros(7)}
 
     with torch.no_grad():
         benchmark(policy.forward, inputs)
@@ -28,7 +28,7 @@ def test_policy_performance(policy, benchmark):
 
 @pytest.mark.benchmark(group="scripted")
 def test_scripted_policy_performance(policy, benchmark):
-    inputs = {"joint_pos": torch.zeros(7), "joint_vel": torch.zeros(7)}
+    inputs = {"joint_positions": torch.zeros(7), "joint_velocities": torch.zeros(7)}
     scripted_policy = torch.jit.script(policy)
 
     with torch.no_grad():


### PR DESCRIPTION
Rename/modify fields of `state_dict` that's being input into controllers to better resemble the protobuf message `RobotState`.

## Changes proposed:
- Rename field: joint_pos --> joint_positions
- Rename field: joint_vel --> joint_velocities
- Add field: motor_torques_measured
- Add field: motor_torques_external


## Test plan:
<!--
How did you verify your changes are correct?
Did you add unit tests?
-->
Benchmarked performance of the Polymetis server using the `empty_statistics_client`, to compare the effect of adding the motor torque fields.
- Before: `max: 0.436474, min: 0.166933, avg: 0.178591`
- After: `max: 0.281875, min: 0.182256, avg: 0.193694`